### PR TITLE
fix ready check bug in monitor

### DIFF
--- a/src/main/scala/tilelink/Monitor.scala
+++ b/src/main/scala/tilelink/Monitor.scala
@@ -798,7 +798,8 @@ class TLMonitor(args: TLMonitorArgs, monitorDir: MonitorDirection = MonitorDirec
       }
     }
 
-    when(bundle.d.valid && d_first && c_first && bundle.c.valid && (bundle.c.bits.source === bundle.d.bits.source) && d_release_ack) {
+    val c_release = bundle.c.bits.opcode === TLMessages.Release || bundle.c.bits.opcode === TLMessages.ReleaseData
+    when(bundle.d.valid && d_first && c_first && bundle.c.valid && (bundle.c.bits.source === bundle.d.bits.source) && d_release_ack && c_release) {
       assume((!bundle.d.ready) || bundle.c.ready, "ready check")
     }
 


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: proposal

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
ProbeAck on Channel C can use the same source as ReleaseAck on Channel D, but it doesn't need to do ready check in this situation
