### PR TITLE
fix(RVCDecoder, Zcmop): Zcmop instrs should be legal

### DIFF
--- a/src/main/scala/rocket/RVC.scala
+++ b/src/main/scala/rocket/RVC.scala
@@ -214,8 +214,10 @@ class RVCDecoder(x: UInt, xLen: Int, fLen: Int, useAddiForMv: Boolean = false) {
   def q1_ill = {
     def rd0 = if (xLen == 32) false.B else rd === 0.U
     def immz = !(x(12) | x(6, 2).orR)
+    def mop = !x(11) && x(7)
+    def lui_res = immz && !mop
     def arith_res = x(12, 10).andR && (if (xLen == 32) true.B else x(6) === 1.U)
-    Seq(false.B, rd0, false.B, immz, arith_res, false.B, false.B, false.B)
+    Seq(false.B, rd0, false.B, lui_res, arith_res, false.B, false.B, false.B)
   }
 
   def q2_ill = {


### PR DESCRIPTION
Ref: RISC-V Unprivileged Specification version 20240411, Section 11.1 "Zcmop" Compressed May-Be-Operations Extension, Version 1.0

`c.lui` with `imm=0` and `rd=xn` should be interpreted as `c.mop.n` (n=1/3/5/7/9/11/13/15), not illegal instruction.

Zcmop instruction expansion is implemented in e994ab3db6c30dd1bfa7cface157aa5e83470cde, but illegal instruction detection is not modified. This PR fixes that mistake.