### PR TITLE
feat(CLINT): delay `io.rtcTick` a cycle for `io.time.valid`

### DIFF
--- a/src/main/scala/devices/tilelink/CLINT.scala
+++ b/src/main/scala/devices/tilelink/CLINT.scala
@@ -80,7 +80,7 @@ class CLINT(params: CLINTParams, beatBytes: Int)(implicit p: Parameters) extends
       int(1) := ShiftRegister(time.asUInt >= timecmp(i).asUInt, params.intStages) // mtip
     }
 
-    io.time.valid := io.rtcTick
+    io.time.valid := RegNext(io.rtcTick)
     io.time.bits := time
 
     /* 0000 msip hart 0


### PR DESCRIPTION
`io.time.valid` may cross clock domain. We delay a cycle through a ff to guarantee that the signal is driven by a register.

This also aligns the `io.time.valid` with the newly updated `time`.