### PR TITLE
fix(Zcb): fix ill insn check for zcb arith insn

### DIFF
--- a/src/main/scala/rocket/RVC.scala
+++ b/src/main/scala/rocket/RVC.scala
@@ -217,8 +217,7 @@ class RVCDecoder(x: UInt, xLen: Int, fLen: Int, useAddiForMv: Boolean = false) {
     def immz = !(x(12) | x(6, 2).orR)
     def mop = !x(11) && x(7)
     def lui_res = immz && !mop
-    def arith_res = x(12, 10).andR && (if (xLen == 32) true.B else x(6) === 1.U)
-    Seq(false.B, rd0, false.B, lui_res, arith_res, false.B, false.B, false.B)
+    Seq(false.B, rd0, false.B, lui_res, false.B, false.B, false.B, false.B)
   }
 
   def q2_ill = {


### PR DESCRIPTION
Fixed the illegal instruction judgment condition of the zcb arithmetic instruction.
c.zext.b, c.sext.b, c.zext.h, c.sext.h, c.zext.w, c.not, c.mul
