### PR TITLE
fix(RVCDecoder): Identify incorrect c.sh instructions

### DIFF
--- a/src/main/scala/rocket/RVC.scala
+++ b/src/main/scala/rocket/RVC.scala
@@ -206,7 +206,7 @@ class RVCDecoder(x: UInt, xLen: Int, fLen: Int, useAddiForMv: Boolean = false) {
     def immz = !(x(12, 5).orR)
     def fld = if (fLen >= 64) false.B else true.B
     def flw32 = if (xLen == 64 || fLen >= 32) false.B else true.B
-    def ldst_zcb = x(12)
+    def ldst_zcb = x(12) || (x(11) && x(10) && x(6))
     def fsd = if (fLen >= 64) false.B else true.B
     def fsw32 = if (xLen == 64 || fLen >= 32) false.B else true.B
     Seq(immz, fld, false.B, flw32, ldst_zcb, fsd, false.B, fsw32)


### PR DESCRIPTION
For c.sh instruction, x(6) must be zero.
