### PR TITLE
fix(DiffStoreEvent): set IO of StoreEventmodule to DontCare

### DIFF
--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -960,7 +960,7 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   io.cpu.resp.bits.store_data := pstore1_data
   if (true) {
     val resp = io.cpu.resp
-    val difftest = DifftestModule(new DiffStoreEvent, delay = 3)
+    val difftest = DifftestModule(new DiffStoreEvent, delay = 3, dontCare = true)
     difftest.coreid := 0.U
     difftest.index  := 0.U
     difftest.valid  := resp.valid && !resp.bits.has_data


### PR DESCRIPTION
Added pc and robidx for difftest store event.
Considering squash, pc and idx are hardcoded into the bundle instead of creating a new difftest event.
Therefore, the store event of rocket needs to be set to dontcare to pass CI.

Here are the difftest-related changes: https://github.com/OpenXiangShan/difftest/commit/87ba05bddb941bfba26460f49c07204037dbb4db