### PR TITLE
fix(RVCDecoder): compressed fp instrs should be illegal when fs is off

### DIFF
--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -240,7 +240,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
       val rvcBranch = bits === Instructions.C_BEQZ || bits === Instructions.C_BNEZ
       val rvcJAL = (xLen == 32).B && bits === Instructions32.C_JAL
       val rvcJump = bits === Instructions.C_J || rvcJAL
-      val rvcImm = Mux(bits(14), new RVCDecoder(bits, xLen, fLen).bImm.asSInt, new RVCDecoder(bits, xLen, fLen).jImm.asSInt)
+      val rvcImm = Mux(bits(14), new RVCDecoder(bits, false.B, xLen, fLen).bImm.asSInt, new RVCDecoder(bits, false.B, xLen, fLen).jImm.asSInt) // FIXME: fsIsOff is only used in XiangShan, not in rocket-chip
       val rvcJR = bits === Instructions.C_MV && bits(6,2) === 0.U
       val rvcReturn = rvcJR && BitPat("b00?01") === bits(11,7)
       val rvcJALR = bits === Instructions.C_ADD && bits(6,2) === 0.U

--- a/src/main/scala/rocket/IBuf.scala
+++ b/src/main/scala/rocket/IBuf.scala
@@ -85,6 +85,7 @@ class IBuf(implicit p: Parameters) extends CoreModule {
   def expand(i: Int, j: UInt, curInst: UInt): Unit = if (i < retireWidth) {
     val exp = Module(new RVCExpander)
     exp.io.in := curInst
+    exp.io.fsIsOff := false.B // FIXME: used only in XiangShan, not in rocket-chip
     io.inst(i).bits.inst := exp.io.out
     io.inst(i).bits.raw := curInst
 


### PR DESCRIPTION
c.fld / c.fsd / c.flw / c.fsw / c.fldsp / c.fsdsp / c.flwsp / c.fswsp should be illegal when `xstatus.fs === 0.U` (x=m/hs/vs/... depending on current priviledge mode)

And:
- for RV64 and RV128 (`xLen >= 64`), c.fxw / c.fxwsp should be interpreted as c.xd / c.xdsp (x=l/s)
- for RV128 (`xLen == 128`), c.fxd / c.fxdsp should be interpreted as c.xq / c.xqsp (x=l/s)

These integer instructions are always legal except for c.ldsp/c.lqsp which requires `rd != x0`.

Also:
- for implementation without F-extension (`!(fLen >= 32)`), c.fxw / c.fxwsp / c.fxd / c.fxdsp is always illegal (x=l/s)
- for implementation without D-extension (`!(fLen >= 64)`), c.fxd / c.fxdsp is always illegal (x=l/s)