### PR TITLE
fix(RVCDecoder): add check for zcb reserved space

### DIFF
--- a/src/main/scala/rocket/RVC.scala
+++ b/src/main/scala/rocket/RVC.scala
@@ -224,7 +224,8 @@ class RVCDecoder(x: UInt, fsIsOff: Bool, xLen: Int, fLen: Int, useAddiForMv: Boo
     def immz = !(x(12) | x(6, 2).orR)
     def mop = !x(11) && x(7)
     def lui_res = immz && !mop
-    Seq(false.B, rd0, false.B, lui_res, false.B, false.B, false.B, false.B)
+    def zcb_res = x(12, 10).andR && x(6, 3).andR
+    Seq(false.B, rd0, false.B, lui_res, zcb_res, false.B, false.B, false.B)
   }
 
   def q2_ill = {


### PR DESCRIPTION
For zcb arithmetic instruction, x(12, 10) is "111",  x(6, 5) is "11" or "10". When x(6, 5) is "11", x(4, 2) = "110" or x(4, 2) = "111" is reserved.

