### PR TITLE
feat(CMO): add TLEdgeOut req transfer for cache block operation

### DIFF
--- a/src/main/scala/tilelink/Bundles.scala
+++ b/src/main/scala/tilelink/Bundles.scala
@@ -40,9 +40,9 @@ object TLMessages
   def GrantAck       = 0.U     //                         .
 
   // *Expand A channel to 4 bits*     A    B    C    D    E
-  def CBOClean       = 8.U     //     .                        => cbo.clean   (Custom since Kunminghu V2)
-  def CBOFlush       = 9.U     //     .                        => cbo.flush   (Custom since Kunminghu V2)
-  def CBOInval       = 10.U    //     .                        => cbo.inval   (Custom since Kunminghu V2)
+  def CBOClean       = 12.U    //     .                        => cbo.clean   (Custom since Kunminghu V2)
+  def CBOFlush       = 13.U    //     .                        => cbo.flush   (Custom since Kunminghu V2)
+  def CBOInval       = 14.U    //     .                        => cbo.inval   (Custom since Kunminghu V2)
   // *Expand D channel to 4 bits*     A    B    C    D    E
   def CBOAck         = 8.U     //                    .         => Ack of CBOs (Custom since Kunminghu V2)
 

--- a/src/main/scala/tilelink/Edges.scala
+++ b/src/main/scala/tilelink/Edges.scala
@@ -89,7 +89,7 @@ class TLEdge(
 
   def hasData(x: TLChannel): Bool = {
     val opdata = x match {
-      case a: TLBundleA => !(a.opcode(2) ^ a.opcode(3))
+      case a: TLBundleA => !a.opcode(2)
         //    opcode === TLMessages.PutFullData    ||
         //    opcode === TLMessages.PutPartialData ||
         //    opcode === TLMessages.ArithmeticData ||


### PR DESCRIPTION
* Add TLEdgeOut req transfer for cache block operation.
* Update opcode for CMO reqs to follow the rules of `hasData()` judgement.