### PR TITLE
fix(DM): fix extTrigger in debug module

### DIFF
--- a/src/main/scala/devices/debug/Debug.scala
+++ b/src/main/scala/devices/debug/Debug.scala
@@ -1118,12 +1118,12 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
       }
 
       for (hg <- 1 to nHaltGroups) {
-        hgHartFiring(hg) := hartHaltedWrEn & ~haltedBitRegs(hartHaltedId) & (hgParticipateHart(hartSelFuncs.hartIdToHartSel(hartHaltedId)) === hg.U)
+        hgHartFiring(hg) := hartHaltedWrEn & ~haltedBitRegs(hartSelFuncs.hartIdToHartSel(hartHaltedId)) & (hgParticipateHart(hartSelFuncs.hartIdToHartSel(hartHaltedId)) === hg.U)
         hgHartsAllHalted(hg) := (haltedBitRegs.asBools | hgParticipateHart.map(_ =/= hg.U)).reduce(_ & _)
 
         when (~io.dmactive || ~dmAuthenticated) {
           hgFired(hg) := false.B
-        }.elsewhen (~hgFired(hg) & (hgHartFiring(hg) | hgTrigFiring(hg))) {
+        }.elsewhen (~hgFired(hg) & ~hgHartsAllHalted(hg) & (hgHartFiring(hg) | hgTrigFiring(hg))) {
           hgFired(hg) := true.B
         }.elsewhen ( hgFired(hg) & hgHartsAllHalted(hg) & hgTrigsAllAcked(hg)) {
           hgFired(hg) := false.B
@@ -1141,7 +1141,7 @@ class TLDebugModuleInner(device: Device, getNComponents: () => Int, beatBytes: I
         for (trig <- 0 until nExtTriggers) {
           extTriggerOutReq(trig) := hgFired(hgParticipateTrig(trig))
         }
-        extTrigger.out.req := extTriggerOutReq.asUInt
+        extTrigger.out.req := extTriggerOutReq.asUInt & (~extTrigger.in.ack).asUInt
       }
     }
     io.hgDebugInt := hgDebugInt | hrDebugInt


### PR DESCRIPTION
 * Index of `haltedBitsRegs` should be `hartSelFuncs.hartIdToHartSel(hartHaltedId)`
 * The receiver of a trigger request should not initiate the same trigger again (It's not strictly required, next line is enough).
 * When all harts in a halt group are halted, the extTrigger requests for that group should no longer be processed; otherwise, infinite extTrigger requests will be generated between the debug modules.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report | feature request | other enhancement

<!-- choose one -->
**Impact**: no functional change | API addition (no impact on existing code) | API modification

<!-- choose one -->
**Development Phase**: proposal |  implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
